### PR TITLE
AbstractNode, Scalar and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - openjdk7
 script:
   - set -e
-  - mvn clean install -Pcheckstyle
+  - mvn clean install -Pcheckstyle jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
                <version>1.9.5</version>
                <scope>test</scope>
           </dependency>
+          <dependency>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-all</artifactId>
+              <version>1.3</version>
+              <scope>test</scope>
+          </dependency>
+          
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/amihaiemil/camel/AbstractNode.java
+++ b/src/main/java/com/amihaiemil/camel/AbstractNode.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.camel;
+
+import java.util.Collection;
+
+/**
+ * YAML node.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ * @see http://yaml.org/spec/1.2/spec.html#node//
+ * @todo #7:1h/DEV Implement and unit test Sequence node.
+ *  See specification: http://yaml.org/spec/1.2/spec.html#sequence//
+ * @todo #7:1h/DEV Implement and unit test Mapping node.
+ *  See specification: http://yaml.org/spec/1.2/spec.html#mapping//
+ */
+abstract class AbstractNode {
+
+    /**
+     * Parents of this node.
+     */
+    private Collection<AbstractNode> parents;
+    
+    /**
+     * Children of this node.
+     */
+    private Collection<AbstractNode> children;
+
+    /**
+     * Ctor.
+     * @param parents Given parents
+     * @param children Given children
+     */
+    AbstractNode(
+        final Collection<AbstractNode> parents,
+        final Collection<AbstractNode> children
+    ) {
+        if(parents.isEmpty()) {
+            throw new IllegalStateException(
+                "A YAML graph cannot have orphaned nodes"
+            );
+        }
+        this.parents = parents;
+        this.children = children;
+    }
+    
+    /**
+     * Fetch the parent nodes of this node.
+     * @return Collection of {@link AbstractNode}
+     */
+    public Collection<AbstractNode> parents() {
+        return this.parents;
+    }
+    
+    /**
+     * Fetch the child nodes of this node.
+     * @return Collection of {@link AbstractNode}
+     */
+    public Collection<AbstractNode> children() {
+        return this.parents;
+    }
+
+}

--- a/src/main/java/com/amihaiemil/camel/Scalar.java
+++ b/src/main/java/com/amihaiemil/camel/Scalar.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.camel;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * YAML scalar.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ * @see http://yaml.org/spec/1.2/spec.html#scalar//
+ * @param <T> Type of the scalar.
+ */
+final class Scalar<T> extends AbstractNode {
+
+    /**
+     * This scalar's value.
+     */
+    private T value;
+
+    /**
+     * Ctor.
+     * @param parents Parent nodes
+     * @param value Given value for this scalar.
+     */
+    Scalar(
+        final Collection<AbstractNode> parents,
+        final T value
+    ) {
+        super(parents, new LinkedList<AbstractNode>());
+        this.value = value;
+    }
+
+    /**
+     * Value of this scalar.
+     * @return Value of type T.
+     */
+    T value() {
+        return this.value;
+    }
+}

--- a/src/test/java/com/amihaiemil/camel/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/camel/ScalarTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.camel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link Scalar}
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ *
+ */
+public final class ScalarTest {
+
+    /**
+     * Scalar can return its own value.
+     */
+    @Test
+    public void returnsValue() {
+        final String val = "test scalar value";
+        final Scalar<String> scl = new Scalar<String>(
+            Arrays.asList(Mockito.mock(AbstractNode.class)),
+            val
+        );
+        MatcherAssert.assertThat(
+            scl.value(), Matchers.equalTo(val)
+        );
+    }
+    
+    /**
+     * Scalar throws ISE if no parents are specified.
+     */
+    @Test (expected = IllegalStateException.class)
+    public void orphanForbidden() {
+        new Scalar<String>(
+            new ArrayList<AbstractNode>(), "orphan"
+        );
+    }
+}


### PR DESCRIPTION
PR for #7 
Implemented AbstractNode which should be extendded by all types of YAML nodes.
Implemented and unit tested Scalar.

Package protected classes since clients are not supposed to see them - YAML objects will be built via builders and later on the processes of loading and dumping will also be encapsulated.

These are first drafts and might change in the near future.