### PR TITLE
children() method made abstract + unit test

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,7 +36,6 @@
     default locale which may vary between environments.
     -->
     <property name="localeLanguage" value="en"/>
-
     <!--
     Checks that property files contain the same keys.
     -->

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
                        <phase>validate</phase>
                        <configuration>
                          <configLocation>checkstyle.xml</configLocation>
+                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                          <encoding>UTF-8</encoding>
                          <consoleOutput>true</consoleOutput>
                          <failsOnError>true</failsOnError>

--- a/src/main/java/com/amihaiemil/camel/AbstractNode.java
+++ b/src/main/java/com/amihaiemil/camel/AbstractNode.java
@@ -46,28 +46,18 @@ abstract class AbstractNode {
      * Parents of this node.
      */
     private Collection<AbstractNode> parents;
-    
-    /**
-     * Children of this node.
-     */
-    private Collection<AbstractNode> children;
 
     /**
      * Ctor.
      * @param parents Given parents
-     * @param children Given children
      */
-    AbstractNode(
-        final Collection<AbstractNode> parents,
-        final Collection<AbstractNode> children
-    ) {
+    AbstractNode(final Collection<AbstractNode> parents) {
         if(parents.isEmpty()) {
             throw new IllegalStateException(
                 "A YAML graph cannot have orphaned nodes"
             );
         }
         this.parents = parents;
-        this.children = children;
     }
     
     /**
@@ -77,13 +67,11 @@ abstract class AbstractNode {
     public Collection<AbstractNode> parents() {
         return this.parents;
     }
-    
+
     /**
      * Fetch the child nodes of this node.
      * @return Collection of {@link AbstractNode}
      */
-    public Collection<AbstractNode> children() {
-        return this.parents;
-    }
+    public abstract Collection<AbstractNode> children();
 
 }

--- a/src/main/java/com/amihaiemil/camel/Scalar.java
+++ b/src/main/java/com/amihaiemil/camel/Scalar.java
@@ -54,7 +54,7 @@ final class Scalar<T> extends AbstractNode {
         final Collection<AbstractNode> parents,
         final T value
     ) {
-        super(parents, new LinkedList<AbstractNode>());
+        super(parents);
         this.value = value;
     }
 
@@ -64,5 +64,10 @@ final class Scalar<T> extends AbstractNode {
      */
     T value() {
         return this.value;
+    }
+
+    @Override
+    public Collection<AbstractNode> children() {
+        return new LinkedList<AbstractNode>();
     }
 }

--- a/src/test/java/com/amihaiemil/camel/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/camel/ScalarTest.java
@@ -57,6 +57,21 @@ public final class ScalarTest {
             scl.value(), Matchers.equalTo(val)
         );
     }
+
+    /**
+     * A Scalar shouldn't have any child nodes.
+     */
+    @Test
+    public void hasNoChildren() {
+    	final String val = "test scalar value";
+        final Scalar<String> scl = new Scalar<String>(
+            Arrays.asList(Mockito.mock(AbstractNode.class)),
+            val
+        );
+        MatcherAssert.assertThat(
+            scl.children(), Matchers.emptyIterable()
+        );
+    }
     
     /**
      * Scalar throws ISE if no parents are specified.

--- a/src/test/java/com/amihaiemil/camel/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/camel/ScalarTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 /**
- * Unit tests for {@link Scalar}
+ * Unit tests for {@link Scalar}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -63,7 +63,7 @@ public final class ScalarTest {
      */
     @Test
     public void hasNoChildren() {
-    	final String val = "test scalar value";
+        final String val = "test scalar value";
         final Scalar<String> scl = new Scalar<String>(
             Arrays.asList(Mockito.mock(AbstractNode.class)),
             val


### PR DESCRIPTION
PR for #12 

Turned that method abstract because it's more complicated to know a Node's children at its instantiation.

And besides that, a Node always knows its children and can implement the method itself.
e.g. the children of a Mapping node are it's values